### PR TITLE
v0.0.5 facelift

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -23,7 +23,9 @@ from . import utils
 from .thruster import (
     ThrusterProperties,
     OBJECT_OT_add_thruster,
-    OBJECT_PT_thruster_panel
+    OBJECT_PT_thruster_panel,
+    OBJECT_PT_thruster_panel_control,
+    OBJECT_PT_thruster_panel_offset
 )
 from .engine import (
     EngineProperties,
@@ -43,7 +45,11 @@ from .menu import (
 # Addon metadata
 bl_info = {
     "name": "Kitten export",
+    "description": "A Blender addon for exporting spacecraft models to Kitten Space Agency (KSA) format with support for thrusters, engines, meshes, and materials.",
+    "author": "Marcus Zuber",
+    "version": (0, 0, 5),
     "blender": (4, 50, 0),
+    "location": "Add Menu > KSA folder, and File > Export > KSA Part",
     "category": ["Add Mesh", "Import-Export"],
 }
 
@@ -54,6 +60,8 @@ classes = (
     OBJECT_OT_add_thruster,
     OBJECT_OT_add_engine,
     OBJECT_PT_thruster_panel,
+    OBJECT_PT_thruster_panel_control,
+    OBJECT_PT_thruster_panel_offset,
     OBJECT_PT_engine_panel,
     OBJECT_OT_export_ksa_metadata,
     OBJECT_OT_export_glb_with_meta,

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -3,7 +3,7 @@ schema_version = "1.0.0"
 # Example of manifest file for a Blender extension
 # Change the values according to your extension
 id = "kittenExport"
-version = "0.0.4"
+version = "0.0.5"
 name = "Kitten Space Agency Exporter"
 tagline = "Export your models to Kitten Space Agency format"
 maintainer = "Marcus Zuber"

--- a/utils.py
+++ b/utils.py
@@ -240,3 +240,16 @@ def _indent_xml(elem, level=0):
     else:
         if not elem.text or not elem.text.strip():
             elem.text = ''
+
+
+def prop_with_unit(layout, props, prop_name, unit, factor_edit=0.92): # layout for units after the numbers
+
+    prop_rna = props.bl_rna.properties[prop_name]
+    label = prop_rna.name
+    
+    split = layout.split(factor=factor_edit, align=True)
+    col_left = split.column(align=True)
+    col_right = split.column(align=True)
+
+    col_left.prop(props, prop_name, text=label)
+    col_right.label(text=unit)


### PR DESCRIPTION
UI revised a bit to be more similar to Blender. Engine and thruster properties moved to Data tab from Object to be more intuitive. Descriptions to properties added. Default empty size and orientation changed to be more comfortable to use. Engine is pointed towards -X by default, which is thrust direction for KSA models in Blender.